### PR TITLE
Add zipfile connection function

### DIFF
--- a/R/unark.R
+++ b/R/unark.R
@@ -148,6 +148,18 @@ compressed_file <- function(path, ...){
          gz = gzfile(path, ...),
          bz2 = bzfile(path, ...),
          xz = xzfile(path, ...),
-         zip = unz(path, ...),
+         zip = zipfile(path, ...),
          file(path, ...))
+}
+
+# Taken from the `readr` package
+zipfile <- function(path, open = "r") {
+  files <- utils::unzip(path, list = TRUE)
+  file <- files$Name[[1]]
+  
+  if (nrow(files) > 1) {
+    message("Multiple files in zip: reading '", file, "'")
+  }
+  
+  unz(path, file, open = open)
 }


### PR DESCRIPTION
This PR is not yet ready to merge but tries to fix unarking of zipfiles.  Zips are a bit different in that they are like little filesystems, so need a different connection call to specify the file inside from which to read.  I've lifted this bit of code from `readr` to deal with this.  Unfortunately, it doesn't quite work.  As implemented here,
I get this error when connecting:

```
 Error in readLines(con, n = 1L) : seek not enabled for this connection 
```

When I force the connection type too be `""` rather than `"r"` for some reason (voodoo found [here](http://r.789695.n4.nabble.com/reading-file-in-zip-archive-td4631853.html)), the function continues but gets stuck in a read loop, like it never reaches the end of the file.  Any ideas?