### PR TITLE
Patch Postgres -  More robust mechanism for getting header

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: arkdb
-Version: 0.0.4
+Version: 0.0.4.99
 Title: Archive and Unarchive Databases Using Flat Files
 Description: Flat text files provide a robust, compressible, and portable
   way to store tables from databases.  This package provides convenient

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,11 @@
 
+# arkdb 0.0.5
+
+- `ark()`'s default `keep-open` method would cut off header names for
+   Postgres connections (due to variation in the behavior of SQL queries
+   with `LIMIT 0`.)  The issue is now resolved by accessing the header in
+   a more robust, general way.
+
 # arkdb 0.0.4
 
 - `unark()` will strip out non-compliant characters in table names by default.

--- a/R/ark.R
+++ b/R/ark.R
@@ -148,10 +148,16 @@ ark_file <- function(tablename,
 }
 
 
+## Generic way to get header
+get_header <- function(db, tablename){
+  fields <- DBI::dbListFields(db, tablename)
+  names(fields) <- fields
+  as.data.frame(lapply(fields, function(x) character(0)))
+}
+
 keep_open <- function(db_con, streamable_table, lines, p, tablename, con){
   ## Create header to avoid duplicate column names
-  query <- paste("SELECT * FROM", tablename, "LIMIT 0")
-  header <- DBI::dbGetQuery(db_con, query)
+  header <- get_header(db_con, tablename)
   streamable_table$write(header, con, omit_header = FALSE)
   
   ## 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Consider the `nycflights` database in SQLite:
 ``` r
 tmp <- tempdir() # Or can be your working directory, "."
 db <- dbplyr::nycflights13_sqlite(tmp)
-#> Caching nycflights db at /var/folders/y8/0wn724zs10jd79_srhxvy49r0000gn/T//RtmpKleZU7/nycflights13.sqlite
+#> Caching nycflights db at /var/folders/y8/0wn724zs10jd79_srhxvy49r0000gn/T//Rtmp3oFbR8/nycflights13.sqlite
 #> Creating table: airlines
 #> Creating table: airports
 #> Creating table: flights
@@ -74,15 +74,15 @@ Create an archive of the database:
 dir <- fs::dir_create(fs::path(tmp, "nycflights"))
 ark(db, dir, lines = 50000)
 #> Exporting airlines in 50000 line chunks:
-#>  ...Done! (in 0.008430958 secs)
+#>  ...Done! (in 0.00859499 secs)
 #> Exporting airports in 50000 line chunks:
-#>  ...Done! (in 0.0249939 secs)
+#>  ...Done! (in 0.03927302 secs)
 #> Exporting flights in 50000 line chunks:
-#>  ...Done! (in 11.82585 secs)
+#>  ...Done! (in 27.67571 secs)
 #> Exporting planes in 50000 line chunks:
-#>  ...Done! (in 0.03939009 secs)
+#>  ...Done! (in 0.2452919 secs)
 #> Exporting weather in 50000 line chunks:
-#>  ...Done! (in 0.799881 secs)
+#>  ...Done! (in 2.398423 secs)
 ```
 
 ## Unarchive
@@ -96,18 +96,18 @@ new_db <- src_sqlite(fs::path(tmp, "local.sqlite"), create=TRUE)
 
 unark(files, new_db, lines = 50000)
 #> Importing airlines.tsv.bz2 in 50000 line chunks:
-#>  ...Done! (in 0.01900196 secs)
+#>  ...Done! (in 0.04621601 secs)
 #> Importing airports.tsv.bz2 in 50000 line chunks:
-#>  ...Done! (in 0.04894209 secs)
+#>  ...Done! (in 0.146152 secs)
 #> Importing flights.tsv.bz2 in 50000 line chunks:
-#>  ...Done! (in 8.526993 secs)
+#>  ...Done! (in 17.44235 secs)
 #> Importing planes.tsv.bz2 in 50000 line chunks:
-#>  ...Done! (in 0.03826308 secs)
+#>  ...Done! (in 0.06386805 secs)
 #> Importing weather.tsv.bz2 in 50000 line chunks:
-#>  ...Done! (in 0.54248 secs)
+#>  ...Done! (in 1.224544 secs)
 
 new_db
-#> src:  sqlite 3.22.0 [/var/folders/y8/0wn724zs10jd79_srhxvy49r0000gn/T/RtmpKleZU7/local.sqlite]
+#> src:  sqlite 3.22.0 [/var/folders/y8/0wn724zs10jd79_srhxvy49r0000gn/T/Rtmp3oFbR8/local.sqlite]
 #> tbls: airlines, airports, flights, planes, weather
 ```
 

--- a/codemeta.json
+++ b/codemeta.json
@@ -10,7 +10,7 @@
   "codeRepository": "https://github.com/ropensci/arkdb",
   "issueTracker": "https://github.com/ropensci/arkdb/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "0.0.4",
+  "version": "0.0.4.99",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -237,7 +237,7 @@
   ],
   "releaseNotes": "https://github.com/ropensci/arkdb/blob/master/NEWS.md",
   "readme": "https://github.com/ropensci/arkdb/blob/master/README.md",
-  "fileSize": "18.99KB",
+  "fileSize": "21.187KB",
   "contIntegration": [
     "https://travis-ci.org/cboettig/arkdb",
     "https://codecov.io/github/cboettig/arkdb?branch=master",
@@ -258,5 +258,10 @@
     "name": "Comprehensive R Archive Network (CRAN)",
     "url": "https://cran.r-project.org"
   },
-  "relatedLink": "https://CRAN.R-project.org/package=arkdb"
+  "relatedLink": "https://CRAN.R-project.org/package=arkdb",
+  "review": {
+    "@type": "Review",
+    "url": "https://github.com/ropensci/onboarding/issues/224",
+    "provider": "http://ropensci.org"
+  }
 }


### PR DESCRIPTION
the keep-open method needs to access  the header names first before getting chunks of returned content.  The previous method used a SELECT call which returned header-only data.frame for some DBs, but not for POSTGRES, which returned empty content. As a result, ark would cut off table column names for Postgres DBs.

This uses a more generic DBI function to access the header, which preserves headers for Postgres and should work with all DBI connection types