### PR TITLE
Set comment.char to "" for read.csv/tsv

### DIFF
--- a/R/streamable_table.R
+++ b/R/streamable_table.R
@@ -125,6 +125,7 @@ streamable_base_tsv <- function() {
                       header = TRUE, 
                       sep = "\t", 
                       quote = "",
+                      comment.char = "",
                       stringsAsFactors = FALSE,
                       ...)
   }
@@ -161,6 +162,7 @@ streamable_base_csv <- function() {
                       header = TRUE, 
                       sep = ",", 
                       quote = "\"",
+                      comment.char = "",
                       stringsAsFactors = FALSE,
                       ...)
   }

--- a/R/streamable_table.R
+++ b/R/streamable_table.R
@@ -120,12 +120,12 @@ streamable_readr_csv <- function() {
 #' 
 #' @importFrom utils read.table write.table 
 streamable_base_tsv <- function() {
-  read_tsv <- function(file, ...) {
+  read_tsv <- function(file, comment.char = "", ...) {
     utils::read.table(textConnection(file), 
                       header = TRUE, 
                       sep = "\t", 
                       quote = "",
-                      comment.char = "",
+                      comment.char = comment.char,
                       stringsAsFactors = FALSE,
                       ...)
   }
@@ -156,13 +156,13 @@ streamable_base_tsv <- function() {
 #' @importFrom utils read.table write.table 
 #' 
 streamable_base_csv <- function() {
-  read_csv <- function(file, ...) {
+  read_csv <- function(file, comment.char = "", ...) {
     ## Consider case of header = FALSE...
     utils::read.table(textConnection(file), 
                       header = TRUE, 
                       sep = ",", 
                       quote = "\"",
-                      comment.char = "",
+                      comment.char = comment.char,
                       stringsAsFactors = FALSE,
                       ...)
   }


### PR DESCRIPTION
While `read.table()` has a default `comment.char="#"`, this is not the default for `read.csv` or any of the functions in `readr`, `data.table`, or `vroom`, so it's unexpected behavior for `#` characters to interrupt reading files. This sets the default to `comment.char="", but allows users to change it.